### PR TITLE
Improve autocomplete for V1.2

### DIFF
--- a/src/main/java/seedu/address/ui/Autocompleter.java
+++ b/src/main/java/seedu/address/ui/Autocompleter.java
@@ -29,15 +29,15 @@ public class Autocompleter {
      */
     public String autocomplete(String commandBoxText) {
         String[] commandBoxTextArray = commandBoxText.trim().split("\\s+");
-        String autocompletedText = commandBoxText;
-        if (commandBoxTextArray.length == 0) {
+        String autocompleteText = commandBoxText;
+        if (commandBoxText.equals("")) {
             raise(new NewResultAvailableEvent(PROMPT_USER_TO_USE_HELP, false));
         } else if (commandBoxTextArray.length == 1) {
-            autocompletedText = processOneWordAutocomplete(commandBoxTextArray[0]);
+            autocompleteText = processOneWordAutocomplete(commandBoxTextArray[0]);
         } else {
 
         }
-        return autocompletedText;
+        return autocompleteText;
     }
 
     private String processOneWordAutocomplete(String commandBoxText) {
@@ -51,7 +51,7 @@ public class Autocompleter {
      * @return ArrayList of possible autocomplete results
      */
     private ArrayList<String> getClosestCommands (String commandBoxText) {
-        ArrayList<String> possibleResults = new ArrayList<String>();
+        ArrayList<String> possibleResults = new ArrayList<>();
         Arrays.stream(commandList)
                 .filter(s -> isPossibleMatch(commandBoxText, s))
                 .forEach(s -> possibleResults.add(s));

--- a/src/main/java/seedu/address/ui/Autocompleter.java
+++ b/src/main/java/seedu/address/ui/Autocompleter.java
@@ -12,26 +12,30 @@ import seedu.address.commons.events.ui.NewResultAvailableEvent;
  */
 public class Autocompleter {
 
-    private static String PROMPT_USER_TO_USE_HELP = "To see what commands are available, type 'help' "
+    private static String PROMPT_USER_TO_USE_HELP_MESSAGE = "To see what commands are available, type 'help' "
             + "into the command box";
+    private static String MULTIPLE_RESULT_MESSAGE = "Multiple matches found";
+
+    private static  String EMPTY_STRING = "";
 
     private final String[] commandList = {"add", "clear", "delete", "edit", "exit", "find", "help", "history", "list",
         "redo", "select", "undo"};
 
+
     public Autocompleter() {
         registerAsAnEventHandler(this);
-    };
+    }
 
     /**
-     *
+     * Returns the autocompleted command to be filled into the command box
      * @param commandBoxText from the command box
-     * @return autocompleted text
+     * @return autocomplete text
      */
     public String autocomplete(String commandBoxText) {
         String[] commandBoxTextArray = commandBoxText.trim().split("\\s+");
         String autocompleteText = commandBoxText;
-        if (commandBoxText.equals("")) {
-            raise(new NewResultAvailableEvent(PROMPT_USER_TO_USE_HELP, false));
+        if (commandBoxText.equals(EMPTY_STRING)) {
+            raise(new NewResultAvailableEvent(PROMPT_USER_TO_USE_HELP_MESSAGE, false));
         } else if (commandBoxTextArray.length == 1) {
             autocompleteText = processOneWordAutocomplete(commandBoxTextArray[0]);
         } else {
@@ -40,9 +44,24 @@ public class Autocompleter {
         return autocompleteText;
     }
 
+    /**
+     *
+     * @param commandBoxText
+     * @return
+     */
     private String processOneWordAutocomplete(String commandBoxText) {
         ArrayList<String> possibleResults = getClosestCommands(commandBoxText);
-        return possibleResults.get(0);
+        switch (possibleResults.size()) {
+            case 0:
+                clearResultsWindow();
+                return commandBoxText;
+            case 1:
+                clearResultsWindow();
+                return possibleResults.get(0);
+            default:
+                raise(new NewResultAvailableEvent(MULTIPLE_RESULT_MESSAGE, false));
+                return commandBoxText;
+        }
     }
 
     /**
@@ -58,9 +77,23 @@ public class Autocompleter {
         return possibleResults;
     }
 
+    /**
+     * Checks if the text in the command box is a substring of a particular command word
+     * @param commandBoxText
+     * @param commandWord
+     */
     private boolean isPossibleMatch(String commandBoxText, String commandWord) {
          return (commandBoxText.length() < commandWord.length()
                 && commandBoxText.equals(commandWord.substring(0, commandBoxText.length())));
+    }
+
+    private void displayMultipleResilts(ArrayList<String> results) {
+        String resultToDisplay = MULTIPLE_RESULT_MESSAGE + "\n";
+
+    }
+
+    private void clearResultsWindow(){
+        raise(new NewResultAvailableEvent(EMPTY_STRING, false));
     }
 
     /**

--- a/src/main/java/seedu/address/ui/Autocompleter.java
+++ b/src/main/java/seedu/address/ui/Autocompleter.java
@@ -12,14 +12,14 @@ import seedu.address.commons.events.ui.NewResultAvailableEvent;
  */
 public class Autocompleter {
 
-    private static String PROMPT_USER_TO_USE_HELP_MESSAGE = "To see what commands are available, type 'help' "
+    private static final String PROMPT_USER_TO_USE_HELP_MESSAGE = "To see what commands are available, type 'help' "
             + "into the command box";
-    private static String MULTIPLE_RESULT_MESSAGE = "Multiple matches found";
+    private static final String MULTIPLE_RESULT_MESSAGE = "Multiple matches found";
 
-    private static  String EMPTY_STRING = "";
+    private static final  String EMPTY_STRING = "";
 
-    private final String[] commandList = {"add", "clear", "delete", "edit", "exit", "find", "help", "history", "list",
-        "redo", "select", "undo"};
+    private static final String[] commandList = {"add", "clear", "delete", "edit", "exit", "find", "help", "history",
+        "list", "redo", "select", "undo"};
 
 
     public Autocompleter() {
@@ -32,7 +32,7 @@ public class Autocompleter {
      * @return autocomplete text
      */
     public String autocomplete(String commandBoxText) {
-        String[] commandBoxTextArray = commandBoxText.toLowerCase().trim().split("\\s+");
+        String[] commandBoxTextArray = commandBoxText.trim().split("\\s+");
         String autocompleteText = commandBoxText;
         if (commandBoxText.equals(EMPTY_STRING)) {
             raise(new NewResultAvailableEvent(PROMPT_USER_TO_USE_HELP_MESSAGE, false));
@@ -50,15 +50,15 @@ public class Autocompleter {
     private String processOneWordAutocomplete(String commandBoxText) {
         ArrayList<String> possibleResults = getClosestCommands(commandBoxText);
         switch (possibleResults.size()) {
-            case 0:
-                clearResultsWindow();
-                return commandBoxText;
-            case 1:
-                clearResultsWindow();
-                return possibleResults.get(0);
-            default:
-                displayMultipleResults(possibleResults);
-                return commandBoxText;
+        case 0:
+            clearResultsWindow();
+            return commandBoxText;
+        case 1:
+            clearResultsWindow();
+            return possibleResults.get(0);
+        default:
+            displayMultipleResults(possibleResults);
+            return commandBoxText;
         }
     }
 
@@ -70,7 +70,7 @@ public class Autocompleter {
     private ArrayList<String> getClosestCommands (String commandBoxText) {
         ArrayList<String> possibleResults = new ArrayList<>();
         Arrays.stream(commandList)
-                .filter(s -> isPossibleMatch(commandBoxText, s))
+                .filter(s -> isPossibleMatch(commandBoxText.toLowerCase(), s))
                 .forEach(s -> possibleResults.add(s));
         return possibleResults;
     }
@@ -81,7 +81,7 @@ public class Autocompleter {
      * @param commandWord
      */
     private boolean isPossibleMatch(String commandBoxText, String commandWord) {
-         return (commandBoxText.length() < commandWord.length()
+        return (commandBoxText.length() < commandWord.length()
                 && commandBoxText.equals(commandWord.substring(0, commandBoxText.length())));
     }
 
@@ -91,13 +91,13 @@ public class Autocompleter {
      */
     private void displayMultipleResults(ArrayList<String> results) {
         String resultToDisplay = MULTIPLE_RESULT_MESSAGE + ":\n";
-        for(String result : results) {
+        for (String result : results) {
             resultToDisplay += result + "\t";
         }
         raise(new NewResultAvailableEvent(resultToDisplay.trim(), false));
     }
 
-    private void clearResultsWindow(){
+    private void clearResultsWindow() {
         raise(new NewResultAvailableEvent(EMPTY_STRING, false));
     }
 

--- a/src/main/java/seedu/address/ui/Autocompleter.java
+++ b/src/main/java/seedu/address/ui/Autocompleter.java
@@ -45,7 +45,7 @@ public class Autocompleter {
     }
 
     /**
-     *
+     * Handle autocomplete when there is only word in the command box
      * @param commandBoxText
      * @return
      */
@@ -59,7 +59,7 @@ public class Autocompleter {
                 clearResultsWindow();
                 return possibleResults.get(0);
             default:
-                raise(new NewResultAvailableEvent(MULTIPLE_RESULT_MESSAGE, false));
+                displayMultipleResults(possibleResults);
                 return commandBoxText;
         }
     }
@@ -87,9 +87,16 @@ public class Autocompleter {
                 && commandBoxText.equals(commandWord.substring(0, commandBoxText.length())));
     }
 
-    private void displayMultipleResilts(ArrayList<String> results) {
+    /**
+     * Creates message to tell user that there are multiple results
+     * @param results
+     */
+    private void displayMultipleResults(ArrayList<String> results) {
         String resultToDisplay = MULTIPLE_RESULT_MESSAGE + "\n";
-
+        for(String result : results) {
+            resultToDisplay += result + " ";
+        }
+        raise(new NewResultAvailableEvent(resultToDisplay.trim(), false));
     }
 
     private void clearResultsWindow(){

--- a/src/main/java/seedu/address/ui/Autocompleter.java
+++ b/src/main/java/seedu/address/ui/Autocompleter.java
@@ -32,14 +32,12 @@ public class Autocompleter {
      * @return autocomplete text
      */
     public String autocomplete(String commandBoxText) {
-        String[] commandBoxTextArray = commandBoxText.trim().split("\\s+");
+        String[] commandBoxTextArray = commandBoxText.toLowerCase().trim().split("\\s+");
         String autocompleteText = commandBoxText;
         if (commandBoxText.equals(EMPTY_STRING)) {
             raise(new NewResultAvailableEvent(PROMPT_USER_TO_USE_HELP_MESSAGE, false));
         } else if (commandBoxTextArray.length == 1) {
             autocompleteText = processOneWordAutocomplete(commandBoxTextArray[0]);
-        } else {
-
         }
         return autocompleteText;
     }
@@ -92,9 +90,9 @@ public class Autocompleter {
      * @param results
      */
     private void displayMultipleResults(ArrayList<String> results) {
-        String resultToDisplay = MULTIPLE_RESULT_MESSAGE + "\n";
+        String resultToDisplay = MULTIPLE_RESULT_MESSAGE + ":\n";
         for(String result : results) {
-            resultToDisplay += result + " ";
+            resultToDisplay += result + "\t";
         }
         raise(new NewResultAvailableEvent(resultToDisplay.trim(), false));
     }

--- a/src/main/java/seedu/address/ui/Autocompleter.java
+++ b/src/main/java/seedu/address/ui/Autocompleter.java
@@ -1,0 +1,81 @@
+package seedu.address.ui;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import seedu.address.commons.core.EventsCenter;
+import seedu.address.commons.events.BaseEvent;
+import seedu.address.commons.events.ui.NewResultAvailableEvent;
+
+/**
+ * Autocomplete utility used in the command box
+ */
+public class Autocompleter {
+
+    private static String PROMPT_USER_TO_USE_HELP = "To see what commands are available, type 'help' "
+            + "into the command box";
+
+    private final String[] commandList = {"add", "clear", "delete", "edit", "exit", "find", "help", "history", "list",
+        "redo", "select", "undo"};
+
+    public Autocompleter() {
+        registerAsAnEventHandler(this);
+    };
+
+    /**
+     *
+     * @param commandBoxText from the command box
+     * @return autocompleted text
+     */
+    public String autocomplete(String commandBoxText) {
+        String[] commandBoxTextArray = commandBoxText.trim().split("\\s+");
+        String autocompletedText = commandBoxText;
+        if (commandBoxTextArray.length == 0) {
+            raise(new NewResultAvailableEvent(PROMPT_USER_TO_USE_HELP, false));
+        } else if (commandBoxTextArray.length == 1) {
+            autocompletedText = processOneWordAutocomplete(commandBoxTextArray[0]);
+        } else {
+
+        }
+        return autocompletedText;
+    }
+
+    private String processOneWordAutocomplete(String commandBoxText) {
+        ArrayList<String> possibleResults = getClosestCommands(commandBoxText);
+        return possibleResults.get(0);
+    }
+
+    /**
+     * Get a list of possible commands to autocomplete
+     * @param commandBoxText
+     * @return ArrayList of possible autocomplete results
+     */
+    private ArrayList<String> getClosestCommands (String commandBoxText) {
+        ArrayList<String> possibleResults = new ArrayList<String>();
+        Arrays.stream(commandList)
+                .filter(s -> isPossibleMatch(commandBoxText, s))
+                .forEach(s -> possibleResults.add(s));
+        return possibleResults;
+    }
+
+    private boolean isPossibleMatch(String commandBoxText, String commandWord) {
+         return (commandBoxText.length() < commandWord.length()
+                && commandBoxText.equals(commandWord.substring(0, commandBoxText.length())));
+    }
+
+    /**
+     * Registers the object as an event handler at the {@link EventsCenter}
+     * @param handler usually {@code this}
+     */
+    private void registerAsAnEventHandler(Object handler) {
+        EventsCenter.getInstance().registerHandler(handler);
+    }
+
+    /**
+     * Raises the event via {@link EventsCenter#post(BaseEvent)}
+     * @param event
+     */
+    protected void raise(BaseEvent event) {
+        EventsCenter.getInstance().post(event);
+    }
+}

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -68,7 +68,7 @@ public class CommandBox extends UiPart<Region> {
      * Updates the text field with the command that is the closest to the current text field string
      */
     private void processAutocomplete() {
-        String currentText = commandTextField.getText().toLowerCase();
+        String currentText = commandTextField.getText();
         String autocompleteText = autocompleter.autocomplete(currentText);
         replaceText(autocompleteText);
     }

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -25,8 +25,7 @@ public class CommandBox extends UiPart<Region> {
 
     private final Logger logger = LogsCenter.getLogger(CommandBox.class);
     private final Logic logic;
-    private final String[] commandList = {"add", "clear", "delete", "edit", "find", "help", "history", "list", "redo",
-        "select", "undo"};
+    private Autocompleter autocompleter = new Autocompleter();
     private ListElementPointer historySnapshot;
 
     @FXML
@@ -58,7 +57,7 @@ public class CommandBox extends UiPart<Region> {
             break;
         case TAB:
             keyEvent.consume();
-            selectClosestResultBasedOnTextFieldValue();
+            processAutocomplete();
             break;
         default:
             // let JavaFx handle the keypress
@@ -68,16 +67,10 @@ public class CommandBox extends UiPart<Region> {
     /**
      * Updates the text field with the command that is the closest to the current text field string
      */
-    private void selectClosestResultBasedOnTextFieldValue() {
+    private void processAutocomplete() {
         String currentText = commandTextField.getText().toLowerCase();
-        if (currentText.length() != 0) {
-            for (String commandWord : commandList) {
-                if (currentText.length() <= commandWord.length()
-                        && currentText.equals(commandWord.substring(0, currentText.length()))) {
-                    replaceText(commandWord);
-                }
-            }
-        }
+        String autocompleteText = autocompleter.autocomplete(currentText);
+        replaceText(autocompleteText);
     }
 
     /**

--- a/src/test/java/guitests/GuiRobot.java
+++ b/src/test/java/guitests/GuiRobot.java
@@ -40,6 +40,14 @@ public class GuiRobot extends FxRobot {
     }
 
     /**
+     * Pauses execution to allow event handler to respond to events
+     *
+     */
+    public void pauseForEvent() {
+        sleep(PAUSE_FOR_HUMAN_DELAY_MILLISECONDS);
+    }
+
+    /**
      * Waits for {@code event} to be true by {@code DEFAULT_WAIT_FOR_EVENT_TIMEOUT_MILLISECONDS} milliseconds.
      *
      * @throws EventTimeoutException if the time taken exceeds {@code DEFAULT_WAIT_FOR_EVENT_TIMEOUT_MILLISECONDS}

--- a/src/test/java/seedu/address/ui/AutocompleterTest.java
+++ b/src/test/java/seedu/address/ui/AutocompleterTest.java
@@ -13,14 +13,14 @@ public class AutocompleterTest extends GuiUnitTest {
     private static final String ADD_COMMAND_WORD = "add";
     private static final String EDIT_COMMAND_WORD = "edit";
     private static final String MULTIPLE_RESULTS_MESSAGE = "Multiple matches found:" + "\n" + "edit" + "\t" + "exit";
-    private static String PROMPT_USER_TO_USE_HELP_MESSAGE = "To see what commands are available, type 'help' "
+    private static final String PROMPT_USER_TO_USE_HELP_MESSAGE = "To see what commands are available, type 'help' "
             + "into the command box";
 
     private ResultDisplayHandle resultDisplayHandle;
     private Autocompleter autocompleter;
 
     @Before
-    public void setUp(){
+    public void setUp() {
         ResultDisplay resultDisplay = new ResultDisplay();
         uiPartRule.setUiPart(resultDisplay);
 
@@ -67,7 +67,7 @@ public class AutocompleterTest extends GuiUnitTest {
 
         // uppercase autocomplete with multiple autocomplete options
         autocompleteResult = autocompleter.autocomplete("E");
-        assertEquals(autocompleteResult, "e");
+        assertEquals(autocompleteResult, "E");
         guiRobot.pauseForHuman();
         assertEquals(MULTIPLE_RESULTS_MESSAGE, resultDisplayHandle.getText());
 
@@ -77,11 +77,6 @@ public class AutocompleterTest extends GuiUnitTest {
         guiRobot.pauseForHuman();
         assertEquals(EMPTY_STRING, resultDisplayHandle.getText());
 
-        // autocomplete with no possible options
-        autocompleteResult = autocompleter.autocomplete("Z");
-        assertEquals(autocompleteResult, "Z");
-        guiRobot.pauseForHuman();
-        assertEquals(EMPTY_STRING, resultDisplayHandle.getText());
     }
 
 }

--- a/src/test/java/seedu/address/ui/AutocompleterTest.java
+++ b/src/test/java/seedu/address/ui/AutocompleterTest.java
@@ -1,0 +1,87 @@
+package seedu.address.ui;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import guitests.guihandles.ResultDisplayHandle;
+
+public class AutocompleterTest extends GuiUnitTest {
+
+    private static final String EMPTY_STRING = "";
+    private static final String ADD_COMMAND_WORD = "add";
+    private static final String EDIT_COMMAND_WORD = "edit";
+    private static final String MULTIPLE_RESULTS_MESSAGE = "Multiple matches found:" + "\n" + "edit" + "\t" + "exit";
+    private static String PROMPT_USER_TO_USE_HELP_MESSAGE = "To see what commands are available, type 'help' "
+            + "into the command box";
+
+    private ResultDisplayHandle resultDisplayHandle;
+    private Autocompleter autocompleter;
+
+    @Before
+    public void setUp(){
+        ResultDisplay resultDisplay = new ResultDisplay();
+        uiPartRule.setUiPart(resultDisplay);
+
+        resultDisplayHandle = new ResultDisplayHandle(getChildNode(resultDisplay.getRoot(),
+                ResultDisplayHandle.RESULT_DISPLAY_ID));
+        autocompleter = new Autocompleter();
+    }
+
+    @Test
+    public void autocomplete() throws Exception {
+        // default result text
+        guiRobot.pauseForHuman();
+        assertEquals(EMPTY_STRING, resultDisplayHandle.getText());
+
+        // autocomplete with empty string
+        String autocompleteResult = autocompleter.autocomplete(EMPTY_STRING);
+        assertEquals(autocompleteResult, EMPTY_STRING);
+        guiRobot.pauseForHuman();
+        assertEquals(PROMPT_USER_TO_USE_HELP_MESSAGE, resultDisplayHandle.getText());
+
+        // lowercase autocomplete with only one autocomplete option
+        autocompleteResult = autocompleter.autocomplete("a");
+        assertEquals(autocompleteResult, ADD_COMMAND_WORD);
+        guiRobot.pauseForHuman();
+        assertEquals(EMPTY_STRING, resultDisplayHandle.getText());
+
+        // uppercase autocomplete with only one autocomplete option
+        autocompleteResult = autocompleter.autocomplete("A");
+        assertEquals(autocompleteResult, ADD_COMMAND_WORD);
+        guiRobot.pauseForHuman();
+        assertEquals(EMPTY_STRING, resultDisplayHandle.getText());
+
+        // mix uppercase and lowercase autocomplete with only one autocomplete option
+        autocompleteResult = autocompleter.autocomplete("Ed");
+        assertEquals(autocompleteResult, EDIT_COMMAND_WORD);
+        guiRobot.pauseForHuman();
+        assertEquals(EMPTY_STRING, resultDisplayHandle.getText());
+
+        // lowercase autocomplete with multiple autocomplete options
+        autocompleteResult = autocompleter.autocomplete("e");
+        assertEquals(autocompleteResult, "e");
+        guiRobot.pauseForHuman();
+        assertEquals(MULTIPLE_RESULTS_MESSAGE, resultDisplayHandle.getText());
+
+        // uppercase autocomplete with multiple autocomplete options
+        autocompleteResult = autocompleter.autocomplete("E");
+        assertEquals(autocompleteResult, "e");
+        guiRobot.pauseForHuman();
+        assertEquals(MULTIPLE_RESULTS_MESSAGE, resultDisplayHandle.getText());
+
+        // autocomplete with no possible options
+        autocompleteResult = autocompleter.autocomplete("Z");
+        assertEquals(autocompleteResult, "Z");
+        guiRobot.pauseForHuman();
+        assertEquals(EMPTY_STRING, resultDisplayHandle.getText());
+
+        // autocomplete with no possible options
+        autocompleteResult = autocompleter.autocomplete("Z");
+        assertEquals(autocompleteResult, "Z");
+        guiRobot.pauseForHuman();
+        assertEquals(EMPTY_STRING, resultDisplayHandle.getText());
+    }
+
+}

--- a/src/test/java/seedu/address/ui/AutocompleterTest.java
+++ b/src/test/java/seedu/address/ui/AutocompleterTest.java
@@ -32,49 +32,49 @@ public class AutocompleterTest extends GuiUnitTest {
     @Test
     public void autocomplete() throws Exception {
         // default result text
-        guiRobot.pauseForHuman();
+        guiRobot.pauseForEvent();
         assertEquals(EMPTY_STRING, resultDisplayHandle.getText());
 
         // autocomplete with empty string
         String autocompleteResult = autocompleter.autocomplete(EMPTY_STRING);
         assertEquals(autocompleteResult, EMPTY_STRING);
-        guiRobot.pauseForHuman();
+        guiRobot.pauseForEvent();
         assertEquals(PROMPT_USER_TO_USE_HELP_MESSAGE, resultDisplayHandle.getText());
 
         // lowercase autocomplete with only one autocomplete option
         autocompleteResult = autocompleter.autocomplete("a");
         assertEquals(autocompleteResult, ADD_COMMAND_WORD);
-        guiRobot.pauseForHuman();
+        guiRobot.pauseForEvent();
         assertEquals(EMPTY_STRING, resultDisplayHandle.getText());
 
         // uppercase autocomplete with only one autocomplete option
         autocompleteResult = autocompleter.autocomplete("A");
         assertEquals(autocompleteResult, ADD_COMMAND_WORD);
-        guiRobot.pauseForHuman();
+        guiRobot.pauseForEvent();
         assertEquals(EMPTY_STRING, resultDisplayHandle.getText());
 
         // mix uppercase and lowercase autocomplete with only one autocomplete option
         autocompleteResult = autocompleter.autocomplete("Ed");
         assertEquals(autocompleteResult, EDIT_COMMAND_WORD);
-        guiRobot.pauseForHuman();
+        guiRobot.pauseForEvent();
         assertEquals(EMPTY_STRING, resultDisplayHandle.getText());
 
         // lowercase autocomplete with multiple autocomplete options
         autocompleteResult = autocompleter.autocomplete("e");
         assertEquals(autocompleteResult, "e");
-        guiRobot.pauseForHuman();
+        guiRobot.pauseForEvent();
         assertEquals(MULTIPLE_RESULTS_MESSAGE, resultDisplayHandle.getText());
 
         // uppercase autocomplete with multiple autocomplete options
         autocompleteResult = autocompleter.autocomplete("E");
         assertEquals(autocompleteResult, "E");
-        guiRobot.pauseForHuman();
+        guiRobot.pauseForEvent();
         assertEquals(MULTIPLE_RESULTS_MESSAGE, resultDisplayHandle.getText());
 
         // autocomplete with no possible options
         autocompleteResult = autocompleter.autocomplete("Z");
         assertEquals(autocompleteResult, "Z");
-        guiRobot.pauseForHuman();
+        guiRobot.pauseForEvent();
         assertEquals(EMPTY_STRING, resultDisplayHandle.getText());
 
     }

--- a/src/test/java/seedu/address/ui/CommandBoxTest.java
+++ b/src/test/java/seedu/address/ui/CommandBoxTest.java
@@ -155,8 +155,9 @@ public class CommandBoxTest extends GuiUnitTest {
         guiRobot.push(KeyCode.ENTER);
 
         // text in text filed is in uppercase
-        guiRobot.push(new KeyCodeCombination(KeyCode.A, KeyCombination.SHIFT_DOWN));
-        assertInputHistory(KeyCode.TAB, "add");
+        guiRobot.push(new KeyCodeCombination(KeyCode.L, KeyCombination.SHIFT_DOWN));
+        assertInputHistory(KeyCode.TAB, COMMAND_THAT_SUCCEEDS);
+        guiRobot.push(KeyCode.ENTER);
 
         // text in text filed is in mix of uppercase and lowercase
         guiRobot.push(new KeyCodeCombination(KeyCode.E, KeyCombination.SHIFT_DOWN));

--- a/src/test/java/seedu/address/ui/CommandBoxTest.java
+++ b/src/test/java/seedu/address/ui/CommandBoxTest.java
@@ -148,7 +148,8 @@ public class CommandBoxTest extends GuiUnitTest {
     }
 
     @Test
-    public void tabAutoCompleteTest_withMatchingCommand() {
+    public void tabAutoCompleteTest_withOneMatchingCommand() {
+        // text in text filed is in lowercase
         guiRobot.push(KeyCode.L);
         assertInputHistory(KeyCode.TAB, COMMAND_THAT_SUCCEEDS);
         guiRobot.push(KeyCode.ENTER);
@@ -156,6 +157,17 @@ public class CommandBoxTest extends GuiUnitTest {
         // text in text filed is in uppercase
         guiRobot.push(new KeyCodeCombination(KeyCode.A, KeyCombination.SHIFT_DOWN));
         assertInputHistory(KeyCode.TAB, "add");
+
+        // text in text filed is in mix of uppercase and lowercase
+        guiRobot.push(new KeyCodeCombination(KeyCode.E, KeyCombination.SHIFT_DOWN));
+        guiRobot.push(KeyCode.D);
+        assertInputHistory(KeyCode.TAB, "edit");
+    }
+
+    @Test
+    public void tabAutoCompleteTest_withMultipleMatchingCommands() {
+        guiRobot.push(KeyCode.E);
+        assertInputHistory(KeyCode.TAB, "e");
     }
 
     /**


### PR DESCRIPTION
Made the following improvements to tab autocomplete:
- Extract out all autocomplete functionalities into a separate class called autocompleter
- Add message to prompt users to use the help command if the command box is empty when tab is pressed
- Add message to display possible options if there is more than one possible autocomplete option