### PR TITLE
Update DeliveryDate to be more strict

### DIFF
--- a/src/main/java/seedu/address/model/parcel/DeliveryDate.java
+++ b/src/main/java/seedu/address/model/parcel/DeliveryDate.java
@@ -49,11 +49,14 @@ public class DeliveryDate {
         // Check if input is in a format we can understand
         if (!isValidDateFormat(trimmedDate)) {
             // Check if input is in a format that PrettyTime(NLP) can understand
-            if (!isValidPrettyTimeDate(trimmedDate)) {
-                throw new IllegalValueException(MESSAGE_DELIVERY_DATE_CONSTRAINTS);
-            } else { // NLP appears to understand the intention, so we accept the input
+            if (isValidPrettyTimeDate(trimmedDate)
+                    && hasMinimumLength(trimmedDate)
+                    && !containsAllNumbers(trimmedDate)) {
+                // NLP appears to understand the intention, so we accept the input
                 List<Date> dates = new PrettyTimeParser().parse(trimmedDate);
                 this.date = dates.get(0);
+            } else {
+                throw new IllegalValueException(MESSAGE_DELIVERY_DATE_CONSTRAINTS);
             }
         } else { // We understand the intention, so we accept the input
             try {
@@ -112,6 +115,18 @@ public class DeliveryDate {
         List<Date> dates = new PrettyTimeParser().parse(test);
 
         return dates.size() > 0;
+    }
+
+    /**
+     * Returns true if a given string is of a minimum length, more than 2 chars
+     */
+    public static boolean hasMinimumLength(String test) {
+        return test.length() > 2;
+    }
+
+    public static boolean containsAllNumbers(String test) {
+        String regex = "\\d+";
+        return test.matches(regex);
     }
 
     private Date getDate() {

--- a/src/main/java/seedu/address/model/parcel/DeliveryDate.java
+++ b/src/main/java/seedu/address/model/parcel/DeliveryDate.java
@@ -124,6 +124,9 @@ public class DeliveryDate {
         return test.length() > 2;
     }
 
+    /**
+     * Returns true if a given string contains all numbers.
+     */
     public static boolean containsAllNumbers(String test) {
         String regex = "\\d+";
         return test.matches(regex);

--- a/src/test/java/seedu/address/model/parcel/DeliveryDateTest.java
+++ b/src/test/java/seedu/address/model/parcel/DeliveryDateTest.java
@@ -18,6 +18,7 @@ public class DeliveryDateTest {
         assertFalse(DeliveryDate.isValidDate(" ")); // spaces only
         assertFalse(DeliveryDate.isValidDate("91")); // less than 3 numbers
         assertFalse(DeliveryDate.isValidDate("9321313213213123212131")); // only numbers, can't understand
+        assertFalse(DeliveryDate.isValidDate("a") // short string
         assertFalse(DeliveryDate.isValidDate("date")); // non-numeric
         assertFalse(DeliveryDate.isValidDate("#(_!@!@(")); // special charactors
         assertFalse(DeliveryDate.isValidDate("\u200E\uD83D\uDE03\uD83D\uDC81")); // emojis

--- a/src/test/java/seedu/address/model/parcel/DeliveryDateTest.java
+++ b/src/test/java/seedu/address/model/parcel/DeliveryDateTest.java
@@ -17,6 +17,7 @@ public class DeliveryDateTest {
         assertFalse(DeliveryDate.isValidDate("")); // empty string
         assertFalse(DeliveryDate.isValidDate(" ")); // spaces only
         assertFalse(DeliveryDate.isValidDate("91")); // less than 3 numbers
+        assertFalse(DeliveryDate.isValidDate("9321313213213123212131")); // only numbers, can't understand
         assertFalse(DeliveryDate.isValidDate("date")); // non-numeric
         assertFalse(DeliveryDate.isValidDate("#(_!@!@(")); // special charactors
         assertFalse(DeliveryDate.isValidDate("\u200E\uD83D\uDE03\uD83D\uDC81")); // emojis
@@ -52,6 +53,7 @@ public class DeliveryDateTest {
         assertEquals(new DeliveryDate("02-08-2017"), new DeliveryDate("Second day of August 2017"));
         assertEquals(new DeliveryDate("4-7-2017"), new DeliveryDate("independence day 2017"));
         assertEquals(new DeliveryDate("14-2-2017"), new DeliveryDate("Valentines day 2017"));
+        assertEquals(new DeliveryDate("24-12-2017"), new DeliveryDate("Christmas eve 2017"));
     }
     //@@author
 

--- a/src/test/java/seedu/address/model/parcel/DeliveryDateTest.java
+++ b/src/test/java/seedu/address/model/parcel/DeliveryDateTest.java
@@ -18,7 +18,7 @@ public class DeliveryDateTest {
         assertFalse(DeliveryDate.isValidDate(" ")); // spaces only
         assertFalse(DeliveryDate.isValidDate("91")); // less than 3 numbers
         assertFalse(DeliveryDate.isValidDate("9321313213213123212131")); // only numbers, can't understand
-        assertFalse(DeliveryDate.isValidDate("a") // short string
+        assertFalse(DeliveryDate.isValidDate("a")); // short string
         assertFalse(DeliveryDate.isValidDate("date")); // non-numeric
         assertFalse(DeliveryDate.isValidDate("#(_!@!@(")); // special charactors
         assertFalse(DeliveryDate.isValidDate("\u200E\uD83D\uDE03\uD83D\uDC81")); // emojis


### PR DESCRIPTION
As per issue raised during acceptance testing, I've updated the delivery date formatter to be more strict. Now does not accept strings with only numbers nor strings with less than 3 characters.